### PR TITLE
Use pdf-parse instead of pdf-poppler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "node-schedule": "^2.1.1",
         "nodeplotlib": "^1.1.2",
         "openai": "^4.86.2",
-        "pdf-poppler": "^0.2.1",
+        "pdf-parse": "^1.1.1",
         "pino": "^9.6.0",
         "puppeteer": "^24.4.0",
         "qrcode": "^1.5.4",
@@ -6551,11 +6551,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/pdf-poppler": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/pdf-poppler/-/pdf-poppler-0.2.1.tgz",
-      "integrity": "sha512-ilrm02mfsha1pR1wmiVKNRIkjvSo70gorg3DIPOzCl6pFU5S39z+gTHLiwIKn808H4YVYVnm6JstUhGNfiGKXg==",
-      "license": "ISC"
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "license": "MIT"
     },
     "node_modules/peek-readable": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node-schedule": "^2.1.1",
     "nodeplotlib": "^1.1.2",
     "openai": "^4.86.2",
-    "pdf-poppler": "^0.2.1",
+    "pdf-parse": "^1.1.1",
     "pino": "^9.6.0",
     "puppeteer": "^24.4.0",
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## Summary
- swap `pdf-poppler` for `pdf-parse`
- use `pdf-parse` to read PDFs and remove poppler-based conversions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d1e3b31c08332b7889b4b99cbfbe6